### PR TITLE
Make r53 store thread safe and read-only external to package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
-ADD istio-route53-static /usr/bin/istio-route53
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+ADD istio-route53-static /usr/bin/istio-route53
 ENTRYPOINT ["/usr/bin/istio-route53"]

--- a/pkg/route53/store.go
+++ b/pkg/route53/store.go
@@ -1,0 +1,50 @@
+package route53
+
+import (
+	"sync"
+)
+
+type (
+	// Store describes a set of endpoint objects from Cloud Map stored by the hostnames that own them.
+	Store interface {
+		// Hosts are all hosts Cloud Map has told us about
+		Hosts() map[string][]endpoint
+
+		// Set updates the cache to reflect the new state
+		// Private to ensure this store is read-only outside of this package
+		set(hosts map[string][]endpoint)
+	}
+
+	store struct {
+		m     *sync.RWMutex
+		hosts map[string][]endpoint // maps host->endpoints
+	}
+)
+
+// New returns a new store which stores Cloud Map data
+func New() Store {
+	return &store{
+		hosts: make(map[string][]endpoint),
+		m:     &sync.RWMutex{},
+	}
+}
+
+func (s *store) Hosts() map[string][]endpoint {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return copyMap(s.hosts)
+}
+
+func (s *store) set(hosts map[string][]endpoint) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.hosts = hosts
+}
+
+func copyMap(m map[string][]endpoint) map[string][]endpoint {
+	out := make(map[string][]endpoint, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/route53/store.go
+++ b/pkg/route53/store.go
@@ -38,13 +38,15 @@ func (s *store) Hosts() map[string][]endpoint {
 func (s *store) set(hosts map[string][]endpoint) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	s.hosts = hosts
+	s.hosts = copyMap(hosts)
 }
 
 func copyMap(m map[string][]endpoint) map[string][]endpoint {
 	out := make(map[string][]endpoint, len(m))
 	for k, v := range m {
-		out[k] = v
+		eps := make([]endpoint, 0) // len 0 forces new slice creation when appending
+		eps = append(eps, v...)
+		out[k] = eps
 	}
 	return out
 }

--- a/pkg/route53/store_test.go
+++ b/pkg/route53/store_test.go
@@ -1,0 +1,19 @@
+package route53
+
+import (
+	"testing"
+)
+
+func Test_store(t *testing.T) {
+	t.Run("Store is read only", func(t *testing.T) {
+		in := map[string][]endpoint{
+			"tetrate.io": []endpoint{endpoint{"1.1.1.1", 53}},
+		}
+		st := New()
+		st.set(in)
+		in["tetrate"] = []endpoint{endpoint{"8.8.8.8", 53}}
+		if st.Hosts()["tetrate.io"][0].host == "8.8.8.8" {
+			t.Errorf("We were able to affect the original input: %v", st.Hosts())
+		}
+	})
+}

--- a/pkg/route53/watcher_test.go
+++ b/pkg/route53/watcher_test.go
@@ -76,22 +76,22 @@ func TestWatcher_refreshCache(t *testing.T) {
 		want        map[string][]endpoint
 	}{
 		{
-			name:        "cache gets updated",
+			name:        "store gets updated",
 			listNsRes:   goldenPathListNamespaces,
 			listSvcRes:  goldenPathListServices,
 			discInstRes: goldenPathDiscoverInstances,
 			want:        map[string][]endpoint{"demo.tetrate.io": []endpoint{endpoint{ipv41, 80}, endpoint{ipv41, 443}}},
 		},
 		{
-			name:      "cache unchanged on ListNamespace error",
+			name:      "store unchanged on ListNamespace error",
 			listNsErr: errors.New("bang"),
-			want:      nil,
+			want:      map[string][]endpoint{},
 		},
 		{
-			name:       "cache unchanged on ListService error",
+			name:       "store unchanged on ListService error",
 			listNsRes:  goldenPathListNamespaces,
 			listSvcErr: errors.New("bang"),
-			want:       nil,
+			want:       map[string][]endpoint{},
 		},
 	}
 	for _, tt := range tests {
@@ -101,10 +101,10 @@ func TestWatcher_refreshCache(t *testing.T) {
 				ListSvcResult: tt.listSvcRes, ListSvcErr: tt.listSvcErr,
 				DiscInstResult: tt.discInstRes, DiscInstErr: tt.discInstErr,
 			}
-			w := &Watcher{cloudmap: mockAPI, r53: mockAPI}
-			w.refreshCache()
-			if !reflect.DeepEqual(w.hostCache, tt.want) {
-				t.Errorf("Watcher.hostCache() = %v, want %v", w.hostCache, tt.want)
+			w := &Watcher{cloudmap: mockAPI, r53: mockAPI, store: New()}
+			w.refreshStore()
+			if !reflect.DeepEqual(w.store.Hosts(), tt.want) {
+				t.Errorf("Watcher.store = %v, want %v", w.store.Hosts(), tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
- Abstract out the r53 cache -> store
- Make store thread safe so it can be consumed by the differ
- Make store read-only outside of package as differ will never need to change it