### PR TITLE
Make r53 store thread safe and read-only external to package

### DIFF
--- a/pkg/route53/infer.go
+++ b/pkg/route53/infer.go
@@ -1,0 +1,23 @@
+package route53
+
+import (
+	"istio.io/api/networking/v1alpha3"
+)
+
+func inferEndpoint(address string, port uint32) *v1alpha3.ServiceEntry_Endpoint {
+	return &v1alpha3.ServiceEntry_Endpoint{
+		Address: address,
+		Ports:   map[string]uint32{inferProto(port): port},
+	}
+}
+
+func inferProto(port uint32) string {
+	switch port {
+	case 80:
+		return "http"
+	case 443:
+		return "https"
+	default:
+		return "tcp"
+	}
+}

--- a/pkg/route53/store.go
+++ b/pkg/route53/store.go
@@ -38,23 +38,15 @@ func (s *store) Hosts() map[string][]endpoint {
 func (s *store) set(hosts map[string][]endpoint) {
 	s.m.Lock()
 	defer s.m.Unlock()
-<<<<<<< HEAD
 	s.hosts = copyMap(hosts)
-=======
-	s.hosts = hosts
->>>>>>> Make r53 store thread safe and read-only external to package
 }
 
 func copyMap(m map[string][]endpoint) map[string][]endpoint {
 	out := make(map[string][]endpoint, len(m))
 	for k, v := range m {
-<<<<<<< HEAD
 		eps := make([]endpoint, 0) // len 0 forces new slice creation when appending
 		eps = append(eps, v...)
 		out[k] = eps
-=======
-		out[k] = v
->>>>>>> Make r53 store thread safe and read-only external to package
 	}
 	return out
 }

--- a/pkg/route53/store.go
+++ b/pkg/route53/store.go
@@ -38,15 +38,23 @@ func (s *store) Hosts() map[string][]endpoint {
 func (s *store) set(hosts map[string][]endpoint) {
 	s.m.Lock()
 	defer s.m.Unlock()
+<<<<<<< HEAD
 	s.hosts = copyMap(hosts)
+=======
+	s.hosts = hosts
+>>>>>>> Make r53 store thread safe and read-only external to package
 }
 
 func copyMap(m map[string][]endpoint) map[string][]endpoint {
 	out := make(map[string][]endpoint, len(m))
 	for k, v := range m {
+<<<<<<< HEAD
 		eps := make([]endpoint, 0) // len 0 forces new slice creation when appending
 		eps = append(eps, v...)
 		out[k] = eps
+=======
+		out[k] = v
+>>>>>>> Make r53 store thread safe and read-only external to package
 	}
 	return out
 }

--- a/pkg/route53/store_test.go
+++ b/pkg/route53/store_test.go
@@ -2,17 +2,21 @@ package route53
 
 import (
 	"testing"
+
+	"istio.io/api/networking/v1alpha3"
 )
 
 func Test_store(t *testing.T) {
 	t.Run("Store is read only", func(t *testing.T) {
-		in := map[string][]endpoint{
-			"tetrate.io": []endpoint{endpoint{"1.1.1.1", 53}},
-		}
-		st := New()
+		in := map[string][]v1alpha3.ServiceEntry_Endpoint{"tetrate.io": []v1alpha3.ServiceEntry_Endpoint{
+			v1alpha3.ServiceEntry_Endpoint{Address: "1.1.1.1", Ports: map[string]uint32{"http": 80}},
+		}}
+		st := NewStore()
 		st.set(in)
-		in["tetrate"] = []endpoint{endpoint{"8.8.8.8", 53}}
-		if st.Hosts()["tetrate.io"][0].host == "8.8.8.8" {
+		in["tetrate"] = []v1alpha3.ServiceEntry_Endpoint{
+			v1alpha3.ServiceEntry_Endpoint{Address: "8.8.8.8", Ports: map[string]uint32{"http": 80}},
+		}
+		if st.Hosts()["tetrate.io"][0].Address == "8.8.8.8" {
 			t.Errorf("We were able to affect the original input: %v", st.Hosts())
 		}
 	})


### PR DESCRIPTION
- Abstract out the r53 cache -> store
- Make store thread safe so it can be consumed by the differ
- Make store read-only outside of package as differ will never need to change it