### PR TITLE
Prepare stores for diffing

### DIFF
--- a/cmd/istio-route53/main.go
+++ b/cmd/istio-route53/main.go
@@ -85,15 +85,15 @@ func serve() (serve *cobra.Command) {
 				return nil
 			})
 
-			seStore := serviceentry.New(id)
+			istio := serviceentry.New(id)
 			if debug {
-				seStore = serviceentry.NewLoggingStore(seStore, log.Printf)
+				istio = serviceentry.NewLoggingStore(istio, log.Printf)
 			}
-			cmStore := route53.NewStore()
+			cloudMap := route53.NewStore()
 
 			ctx := context.Background() // common context for cancellation across all loops/routines
 			log.Print("Starting Route53 watcher")
-			r53Watcher, err := route53.NewWatcher(cmStore)
+			r53Watcher, err := route53.NewWatcher(cloudMap)
 			if err != nil {
 				return err
 			}
@@ -101,7 +101,7 @@ func serve() (serve *cobra.Command) {
 
 			log.Printf("Watching %s.%s across all namespaces with resync period %d and id %q", apiType, kind, resyncPeriod, id)
 			sdk.Watch(apiType, kind, allNamespaces, resyncPeriod)
-			sdk.Handle(serviceentry.NewHandler(seStore))
+			sdk.Handle(serviceentry.NewHandler(istio))
 			sdk.Run(ctx)
 			return nil
 		},

--- a/pkg/route53/infer.go
+++ b/pkg/route53/infer.go
@@ -1,0 +1,23 @@
+package route53
+
+import (
+	"istio.io/api/networking/v1alpha3"
+)
+
+func inferEndpoint(address string, port uint32) *v1alpha3.ServiceEntry_Endpoint {
+	return &v1alpha3.ServiceEntry_Endpoint{
+		Address: address,
+		Ports:   map[string]uint32{inferProto(port): port},
+	}
+}
+
+func inferProto(port uint32) string {
+	switch port {
+	case 80:
+		return "http"
+	case 443:
+		return "https"
+	default:
+		return "tcp"
+	}
+}

--- a/pkg/route53/store_test.go
+++ b/pkg/route53/store_test.go
@@ -2,17 +2,21 @@ package route53
 
 import (
 	"testing"
+
+	"istio.io/api/networking/v1alpha3"
 )
 
 func Test_store(t *testing.T) {
 	t.Run("Store is read only", func(t *testing.T) {
-		in := map[string][]endpoint{
-			"tetrate.io": []endpoint{endpoint{"1.1.1.1", 53}},
-		}
-		st := New()
+		in := map[string][]v1alpha3.ServiceEntry_Endpoint{"tetrate.io": []v1alpha3.ServiceEntry_Endpoint{
+			v1alpha3.ServiceEntry_Endpoint{Address: "1.1.1.1", Ports: map[string]uint32{"http": 80}},
+		}}
+		st := NewStore()
 		st.set(in)
-		in["tetrate"] = []endpoint{endpoint{"8.8.8.8", 53}}
-		if st.Hosts()["tetrate.io"][0].host == "8.8.8.8" {
+		in["tetrate"] = []v1alpha3.ServiceEntry_Endpoint{
+			v1alpha3.ServiceEntry_Endpoint{Address: "8.8.8.8", Ports: map[string]uint32{"http": 80}},
+		}
+		if st.Hosts()["tetrate.io"][0].Address == "8.8.8.8" {
 			t.Errorf("We were able to affect the original input: %v", st.Hosts())
 		}
 	})


### PR DESCRIPTION
- Route53 is changed to talk in terms of ServiceEntry endpoints. 
- This means the differ no longer has to reason about two distinct concepts of an endpoint 
- Externalizes store so they can be consumed by the differ